### PR TITLE
add the trailing / when there is a branch specified

### DIFF
--- a/lib/travis/api/v3/queries/caches.rb
+++ b/lib/travis/api/v3/queries/caches.rb
@@ -22,6 +22,7 @@ module Travis::API::V3
     private
 
     def prefix
+      branch += '/' unless branch.to_s.empty?
       "#{@repo.github_id.to_s}/#{branch}"
     end
 


### PR DESCRIPTION
Alternatively, install it using npm:

                    
npm install opbeat-js --save
<script src="node_modules/opbeat-js/opbeat.min.js"></script>               

Or use bower:                 
bower install opbeat-js --save

<script src="bower_components/opbeat-js/opbeat.min.js"></script>
                